### PR TITLE
Removed additional dead links

### DIFF
--- a/mobx-tutorials.md
+++ b/mobx-tutorials.md
@@ -96,12 +96,8 @@
 
 - **Comparing MobX and Redux - Video**  
   https://www.youtube.com/watch?v=83v8cdvGfeA  
-A great video to understand the differences between MobX and Redux.
-  
-- **Redux vs MobX**  
-  https://medium.com/@himrc/redux-vs-mobx-a42c8950f3  
-  Some quick pros and cons of each, links to other discussions, and thoughts on when to use them.
-  
+  A great video to understand the differences between MobX and Redux.
+
 - **Redux or MobX: What I learned after refactoring a medium-sized React app**  
   https://dannyherran.com/2017/03/react-redux-mobx-takeaways/  
   A useful list of takeaways, pros and cons of each library and the impact on an existing React application.

--- a/pros-cons-discussion.md
+++ b/pros-cons-discussion.md
@@ -231,7 +231,6 @@ similar structures in ClojureScript.
   
 - **"Why is everying in Javascript changing so fast?**  
   https://news.ycombinator.com/item?id=11833301  
-  https://news.ycombinator.com/item?id=12758514  
   Yet another rant thread about Javascript churn, but with a couple very insightful comments about the unique complexities and challenges involved in writing applications for the web.
   
 - **"Youtube is being rebuilt on Web Components"**  

--- a/react-redux-testing.md
+++ b/react-redux-testing.md
@@ -140,11 +140,7 @@
 - **Testing React Components**  
   https://medium.com/@skidding/testing-react-components-30516bc6a1b3  
   Thoughts on good practices for testing React components, based on writing thousands of tests. Describes complexities in testing real-world components that make use of multiple HOCs or that glue different units together, and how the Cosmos tool can help simplify those tests using mocking.
-  
-- **An introduction to testing React components with Enzyme 3**  
-  https://javascriptplayground.com/blog/2017/12/introduction-to-react-tests-enzyme/  
-  Introduces the Enzyme library for testing components, and shows a short TDD approach for writing a component
-  
+ 
 - **Unit test code that uses CSS Modules**  
   https://medium.com/@a_eife/unit-test-code-that-uses-css-modules-ef5b49efc707  
   Provides several solutions for handling imports of CSS Modules when running unit tests

--- a/redux-reducers-selectors.md
+++ b/redux-reducers-selectors.md
@@ -231,7 +231,3 @@
 - **Redux Patterns: Rethinking `byId` and `byHash` Structures**  
   https://hackernoon.com/redux-patterns-rethinking-byid-and-byhash-structures-854e8a0fa32d  
   Thoughts on dropping the common list of "all IDs" in a normalized state structure, and just iterating over all items using `Object.keys()` to grab the IDs.
-
-- **Organising Redux State**  
-  https://medium.com/@onoufriosm/organising-redux-state-4b4c2b99eece  
-  Short examples of how Labstep defines state structure for their normalized entities

--- a/redux-without-react.md
+++ b/redux-without-react.md
@@ -100,15 +100,8 @@
   https://www.sitepoint.com/managing-state-aurelia-with-redux/  
   Covers setting up a standard Aurelia app, adding Redux, and use of redux-undo with the example.
   
-- **Why Aurelia and Redux is a natural and powerful combination**  
-  https://www.softvision.com/blog/aurelia-redux/  
-  Thoughts on the benefits of Aurelia compared to other frameworks, and examples of how to use Redux in an Aurelia app.
-  
-  
 #### Other
 
-
-  
 - **Explorations in Adapting Redux to C#**  
   https://spin.atomicobject.com/2017/03/13/adapting-redux-c-sharp-xamarin/  
   An informative look at how AtomicObject has a Redux variant in C#


### PR DESCRIPTION
# Formatting

Please follow the existing formatting for each entry.  In order to get newlines without paragraph breaks, each entry should have two spaces at the end of the line after both the URL and the title.  Also, two-space indents before the URL and the description.  Example:

```markdown
- **Link Title**<space><space>  
<space><space>http://example.com<space><space>  
<space><space>Link description here
```

Result:

- **Link Title**  
  http://example.com  
  Link description here
  
Please do _not_ strip whitespace for existing entries!
