### PR TITLE
Additional tweaks

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -12,3 +12,4 @@ jobs:
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
           use-quiet-mode: 'yes'
+          use-verbose-mode: 'yes'

--- a/webpack-advanced-techniques.md
+++ b/webpack-advanced-techniques.md
@@ -274,10 +274,6 @@
 - **Webpack and Hot Module Replacement**  
   https://medium.com/@rajaraodv/webpack-hot-module-replacement-hmr-e756a726a07  
   A great in-depth walkthrough of how HMR works
-  
-- **Webpack's HMR and React Hot-Loader - The Missing Manual**  
-  https://medium.com/@rajaraodv/webpacks-hmr-react-hot-loader-the-missing-manual-232336dc0d96  
-  Demonstrates three ways to enable HMR, and usage with three different React application scenarios
 
 - **Hot Reloading in React**  
   https://medium.com/@dan_abramov/hot-reloading-in-react-1140438583bf  


### PR DESCRIPTION
# Formatting

Please follow the existing formatting for each entry.  In order to get newlines without paragraph breaks, each entry should have two spaces at the end of the line after both the URL and the title.  Also, two-space indents before the URL and the description.  Example:

```markdown
- **Link Title**<space><space>  
<space><space>http://example.com<space><space>  
<space><space>Link description here
```

Result:

- **Link Title**  
  http://example.com  
  Link description here
  
Please do _not_ strip whitespace for existing entries!
